### PR TITLE
Updated for installation on Arch systems

### DIFF
--- a/install_deps_arch.sh
+++ b/install_deps_arch.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -o errexit
+
+pacman -Sy
+pacman -S --needed gcc-fortran make sqlite  nginx fcgi spawn-fcgi

--- a/makefile
+++ b/makefile
@@ -6,6 +6,10 @@ LIBSQLITE3=$(shell find /usr -name libsqlite3.a -print -quit)
 FORTRAN=gfortran
 FORTRANFLAGS=-ldl -lfcgi -pthread -Wl,-rpath -Wl,/usr/lib
 
+ifndef $(LIBSQLITE3)
+FORTRANFLAGS=-ldl -lfcgi -lsqlite3 -pthread -Wl,-rpath -Wl,/usr/lib
+endif
+
 OBJECTS = \
 	marsupial.o \
 	jade.o \


### PR DESCRIPTION
makefile uses -lsqlite3 flag if libsqlite3.a is not found

created install_deps_arch.sh for installing dependencies on Arch