### PR TITLE
Correctly escape single quotes in the SQL query, and use INSTR to not…

### DIFF
--- a/marsupial.f90
+++ b/marsupial.f90
@@ -40,8 +40,8 @@ module marsupial
     call sqlite3_column_query( column(3), 'wikiLink', SQLITE_CHAR )
     call sqlite3_column_query( column(4), 'description', SQLITE_CHAR )
 
-    call string_replace(query, "'", "_")
-    call sqlite3_prepare_select( db, 'marsupials', column, stmt, "WHERE LOWER(name) LIKE '%" // trim(query) // "%' LIMIT 4")
+    call string_replace(query, "'", "''")
+    call sqlite3_prepare_select( db, 'marsupials', column, stmt, "WHERE INSTR(LOWER(name), LOWER('" // trim(query) // "')) LIMIT 4")
 
     i = 1
     do

--- a/string_helpers.f90
+++ b/string_helpers.f90
@@ -62,13 +62,15 @@ module string_helpers
       character(len=*), intent(in)    :: substr
       character(len=*), intent(in)    :: replace
 
-      integer                         :: k
+      integer                         :: k, p
 
+      p = 1
       do
-        k = index( string, substr )
+        k = index( string(p:), substr )
         if ( k > 0 ) then
-          call string_delete( string, k, len(substr) )
-          call string_insert( string, k, replace )
+          call string_delete( string(p:), k, len(substr) )
+          call string_insert( string(p:), k, replace )
+          p = p + k - 1 + len(replace)
         else
           exit
         endif


### PR DESCRIPTION
… interpret metacharacters.

This required fixing the escaping function to handle the case of the
replacement matching the source string.

Note: there may still be range errors in there! Not sure how to avoid
writing more than in the buffer, although at least I didn't succeed at
making it crash. It just seems to cut off the string, which in worst case
can cause a SQL error but should not be exploitable as long as there is
only one inserted parameter.

Much better approach would be adding support for bound parameters.

Fixes #6 